### PR TITLE
Replace meaningless langth comparison in code.

### DIFF
--- a/arishem/arishem_rule_execute.go
+++ b/arishem/arishem_rule_execute.go
@@ -214,7 +214,7 @@ func distributeRules(rules []RuleTarget) (priority []RuleTarget, noPriority []Ru
 }
 
 func batchRules(rules []RuleTarget, batchSize int) [][]RuleTarget {
-	if len(rules) < 0 || batchSize <= 0 {
+	if len(rules) <= 0 || batchSize <= 0 {
 		return [][]RuleTarget{rules}
 	}
 	var batches [][]RuleTarget

--- a/tools/slice.go
+++ b/tools/slice.go
@@ -105,7 +105,7 @@ func SliceFilterUint64(arr []uint64, filter []uint64) []uint64 {
 }
 
 func BatchSliceUint64(arr []uint64, batchSize int) [][]uint64 {
-	if len(arr) < 0 || batchSize <= 0 {
+	if len(arr) <= 0 || batchSize <= 0 {
 		return [][]uint64{arr}
 	}
 	var batches [][]uint64
@@ -118,7 +118,7 @@ func BatchSliceUint64(arr []uint64, batchSize int) [][]uint64 {
 }
 
 func BatchSliceInt64(arr []int64, batchSize int) [][]int64 {
-	if len(arr) < 0 || batchSize <= 0 {
+	if len(arr) <= 0 || batchSize <= 0 {
 		return [][]int64{arr}
 	}
 	var batches [][]int64


### PR DESCRIPTION
In file: slice.go, the comparison operation creates a logical short circuit since the length or capacity value can never be negative. I suggested that the length comparison should be done without creating a logical short circuit.

In file: arishem_rule_execute.go, a similar comparison is done. I suggested that the length comparison should be done without creating a logical short circuit.

In both cases, the code update is a suggestion. The actual intention may be different. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.